### PR TITLE
feat: Accomodate API

### DIFF
--- a/daily-shoutout/app.py
+++ b/daily-shoutout/app.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import random
@@ -54,12 +55,21 @@ def sendTweet(tweet_string):
         )  
     client.create_tweet(text = tweet_string)
 
+def returnResponse(response_string):
+    return{
+        "statusCode": 200,
+        "body": json.dumps(response_string)
+    }
+
 
 def lambda_handler(event, context):
     person = people[get_random_index(len(people))]
     cause = causes[get_random_index(len(causes))]
-
-    sendTweet(f"Noted billionare {person} once again contributes nothing to {cause}.")
+    message_string = f"Noted billionare {person} once again contributes nothing to {cause}."
+    if event.get("source", False) == "aws.events":
+        sendTweet(message_string)
+    else:
+        returnResponse(message_string)
 
 if __name__ == "__main__":
     lambda_handler(None, None)

--- a/daily-shoutout/app.py
+++ b/daily-shoutout/app.py
@@ -40,7 +40,7 @@ def get_random_index(list_length):
     return int(random.uniform(0, list_length))
 
 
-def sendTweet(tweet_string):
+def send_tweet(tweet_string):
     consumer_key = os.environ['TWITTER_CONSUMER_KEY']
     consumer_secret = os.environ['TWITTER_CONSUMER_SECRET']
     access_token = os.environ['TWITTER_ACCESS_TOKEN']
@@ -56,7 +56,7 @@ def sendTweet(tweet_string):
     client.create_tweet(text = tweet_string)
 
 
-def returnResponse(response_string):
+def return_response(response_string):
     return{
         "statusCode": 200,
         "body": json.dumps(response_string)
@@ -64,13 +64,13 @@ def returnResponse(response_string):
 
 
 def lambda_handler(event, context):
-    person = people[get_random_index(len(people))]
-    cause = causes[get_random_index(len(causes))]
+    person = random.choice(people)
+    cause = random.choice(causes)
     message_string = f"Noted billionare {person} once again contributes nothing to {cause}."
     if event.get("source", False) == "aws.events":
-        sendTweet(message_string)
+        send_tweet(message_string)
     else:
-        return returnResponse(message_string)
+        return return_response(message_string)
 
 
 if __name__ == "__main__":

--- a/daily-shoutout/app.py
+++ b/daily-shoutout/app.py
@@ -55,6 +55,7 @@ def sendTweet(tweet_string):
         )  
     client.create_tweet(text = tweet_string)
 
+
 def returnResponse(response_string):
     return{
         "statusCode": 200,
@@ -70,6 +71,7 @@ def lambda_handler(event, context):
         sendTweet(message_string)
     else:
         returnResponse(message_string)
+
 
 if __name__ == "__main__":
     lambda_handler(None, None)

--- a/daily-shoutout/app.py
+++ b/daily-shoutout/app.py
@@ -70,8 +70,9 @@ def lambda_handler(event, context):
     if event.get("source", False) == "aws.events":
         sendTweet(message_string)
     else:
-        returnResponse(message_string)
+        return returnResponse(message_string)
 
 
 if __name__ == "__main__":
-    lambda_handler(None, None)
+    response = lambda_handler({}, None)
+    print(response)


### PR DESCRIPTION
Resolves #4 

When invoking the Lambda Function, Cloudwatch Events passes the "event" json object into the lambda handler which contains a key:value pair of {"source":"aws.events"}.

This change takes advantage of that to only send the tweet when invoked by the scheduled event. Otherwise, it will respond with a json object carrying the message. This will allow users to hit an api endpoint (that will be made in the infra repo) and receive a "random" response.